### PR TITLE
Fixed odd code appearing at top of page

### DIFF
--- a/_posts/2011-02-01-a-handy-ruby-trick-class-new.html
+++ b/_posts/2011-02-01-a-handy-ruby-trick-class-new.html
@@ -11,15 +11,21 @@ type: post
 published: true
 ---
 <p>Today I learned that you can pass a block to Class.new, like so:</p>
-<p><code lang="ruby"><br />
-klass = Class.new do<br />
-  def self.speak<br />
-    "hi!"<br />
-  end<br />
-end</p>
-<p>>> klass.speak<br />
-=> "hi!<br />
-</code></p>
+<p>
+  <code lang="ruby"><br />
+    <p>
+      klass = Class.new do<br />
+        def self.speak<br />
+          "hi!"<br />
+        end<br />
+      end<br />
+    <p/>
+    <p>
+      >> klass.speak<br />
+      => "hi!<br />
+    </p>
+  </code>
+</p>
 <p>This is a handy for creating one-off classes; the kind you'll throw away quickly. </p>
 <p>It's likely that you'd do this during tests. Here's a test in active_support that uses this technique:</p>
 <p><code lang="ruby"><br />


### PR DESCRIPTION
The misplaced code is now fixed at the top of the page. There was a missing `<p>` tag. I broke it out so it's a little bit easier to read, if you want me to put it back to how it was just let me know and I can. 
![handy_ruby_fixed](https://cloud.githubusercontent.com/assets/10966357/9829318/38d6366a-58c5-11e5-82c4-16352e5d0912.png)
